### PR TITLE
Use compatibility mode dataplane by default

### DIFF
--- a/legacy_migration/toggle_cfg.py
+++ b/legacy_migration/toggle_cfg.py
@@ -44,7 +44,11 @@ class ToggleConfig(object):
                                {'item': 'extension_drivers',
                                 'section_name': 'group_policy',
                                 'old': None,
-                                'new': DRV}
+                                'new': DRV},
+                               {'item': 'enable_iptables_firewall',
+                                'section_name': 'ml2_apic_aim',
+                                'old': None,
+                                'new': 'True'}
                               ]
 
     def _get_legacy_config(self):


### PR DESCRIPTION
Use the IP Tables based implementation for security groups
by default (i.e. "Compatibility mode data plane") when migrating
from the legacy plugin to the unified plugin.