### PR TITLE
Add OVS tools

### DIFF
--- a/ovs/README.md
+++ b/ovs/README.md
@@ -1,0 +1,33 @@
+This directory contains tooling that is helpful if a customer's data plane
+needs to be reconstructed. 
+
+There are two compoents to the tooling:
+1) python script to create shell script for creating the same
+   network ports/interfaces that are connected to OVS and namespaces
+2) shell script to convert ovs-ofctl flow dumps into commands to
+   create flow-mods.
+
+The python script is used as follows:
+
+[root@overcloud-novacompute-0 OOpenFlow13]# python
+Python 3.6.8 (default, Aug  3 2021, 06:54:29)
+[GCC 8.3.1 20191121 (Red Hat 8.3.1-5)] on linux
+Type "help", "copyright", "credits" or "license" for more information.
+>>> import bridge_ifs
+>>> mgr = bridge_ifs.OVSInterfaceParser()
+>>> mgr.parse_ports('OOpenFlow-int-brfabric')
+>>> mgr.parse_ports('OOpenFlow-int-brint')
+>>> mgr.create_script_file()
+
+This creates a "config-bridges.sh" script, which can be run to create
+the relevant tap ports, patch ports, etc.
+
+A simpler way to recreate the bridges and ports is to obtain the OVSDB
+database, and simply import that. However, that component may not always
+be available, but the output of the "ovs-ofctl show <bridge name>" usually is.
+
+The shell script is run as follows:
+    sh ./create-flowmods.sh <file containing ovs-ofctl dump for a bridge> <name of bridge> > <output-file>
+
+As an example:
+    # sh ./create-flowmods.sh flowmod-dump.txt br-fabric > create-br-fabric-flows.sh

--- a/ovs/bridge_ifs.py
+++ b/ovs/bridge_ifs.py
@@ -1,0 +1,105 @@
+import re
+
+
+
+class OVSInterfaceParser(object):
+    def __init__(self, outfilename='config-bridges.sh'):
+        self.bridge_ports = {}
+        #Matches <ofport number>(<port name>): addr:<mac address>
+        self.ifmatcher = re.compile(r"^ ([0-9A-Z]{1,5})\((.*)\): addr:(.*)")
+        self.cmd_script = outfilename
+    def open_script_file(self):
+        self.script_fd = open(self.cmd_script, "w+")
+    def close_script_file(self):
+        self.script_fd.close()
+    def parse_ports(self, bridge_filename, prefix=None):
+        fd = open(bridge_filename, 'r')
+        alldata = fd.readlines()
+        for line in alldata:
+            groups = self.ifmatcher.match(line)
+            if groups:
+                if not prefix or prefix and groups[2][0:len(prefix)] == prefix:
+                    self.bridge_ports[groups[2]] = {'mac': groups[3],
+                                                    'ofport': groups[1]}
+    def create_tap_ports(self):
+        for port in self.bridge_ports.keys():
+            if port[0:3] == 'tap':
+                cmd = "ip tuntap add %s mode tap\n" % port
+                self.script_fd.write(cmd)
+                cmd = "ip link set %s address %s\n" % (port, self.bridge_ports[port]['mac'])
+                self.script_fd.write(cmd)
+                cmd = "ifconfig %s up\n" % port
+                self.script_fd.write(cmd)
+    def create_snat_ports(self):
+        for port in self.bridge_ports.keys():
+            if port[0:3] == 'of-':
+                cmd = "ip tuntap add %s mode tap\n" % port
+                self.script_fd.write(cmd)
+                cmd = "ip link set %s address %s\n" % (port, self.bridge_ports[port]['mac'])
+                self.script_fd.write(cmd)
+                cmd = "ifconfig %s up\n" % port
+                self.script_fd.write(cmd)
+    def add_tap_ports(self):
+        for port in self.bridge_ports.keys():
+            if port[0:3] == 'tap':
+                cmd = ("ovs-vsctl add-port br-int %s -- set Interface %s ofport=%s\n" %
+                       (port, port, self.bridge_ports[port]['ofport']))
+                self.script_fd.write(cmd)
+    def add_patch_ports(self):
+        for port in self.bridge_ports.keys():
+            if port[0:3] == 'qpf':
+                patch = port.replace('qpf', 'qpi')
+                cmd = ('ovs-vsctl add-port br-int %s -- set Interface %s type=patch ofport=%s mac_in_use=\\"%s\\" options:peer=%s\n' %
+                        (port, port, self.bridge_ports[port]['ofport'], self.bridge_ports[port]['mac'], patch)) 
+                self.script_fd.write(cmd)
+                cmd = ('ovs-vsctl add-port br-fabric %s -- set Interface %s type=patch ofport=%s mac_in_use=\\"%s\\" options:peer=%s\n' %
+                        (patch, patch, self.bridge_ports[patch]['ofport'], self.bridge_ports[patch]['mac'], port))
+                self.script_fd.write(cmd)
+            if port == 'patch-fab-ex':
+                cmd = ('ovs-vsctl -- --may-exist add-port br-fabric patch-fab-ex -- set Interface patch-fab-ex type=patch ofport=%s mac_in_use=\\"%s\\" options:peer=patch-ex-fab\n' %
+                (self.bridge_ports[port]['ofport'], self.bridge_ports[port]['mac']))
+                self.script_fd.write(cmd)
+
+    def add_snat_ports(self):
+        for port in self.bridge_ports.keys():
+            if port[0:3] == 'of-':
+                cmd = ('ovs-vsctl add-port br-fabric %s -- set Interface %s ofport=%s\n' %
+                        (port, port, self.bridge_ports[port]['ofport'])) 
+                self.script_fd.write(cmd)
+
+    def add_gen_ports(self):
+        for port in self.bridge_ports.keys():
+            if port[0:4] == 'gen2':
+                cmd = ('ovs-vsctl -- --may-exist add-port br-int gen2 -- set Interface gen2 type=geneve ofport=%s mac_in_use=\\"%s\\" options:remote_ip=flow options:key=2\n' %
+                (self.bridge_ports[port]['ofport'], self.bridge_ports[port]['mac']))
+                self.script_fd.write(cmd)
+                cmd = 'ovs-vsctl set interface gen2 ingress_policing_rate=1000\n'
+                self.script_fd.write(cmd)
+                cmd = 'ovs-vsctl set interface gen2 ingress_policing_burst=100\n'
+                self.script_fd.write(cmd)
+            if port[0:4] == 'gen1':
+                cmd = ('ovs-vsctl -- --may-exist add-port br-fabric gen1 -- set interface gen1 type=geneve ofport=%s mac_in_use=\\"%s\\" options:remote_ip=flow options:key=1\n' %
+                (self.bridge_ports[port]['ofport'], self.bridge_ports[port]['mac']))
+                self.script_fd.write(cmd)
+                cmd = ('ovs-vsctl set interface gen1 ingress_policing_rate=1000\n')
+                self.script_fd.write(cmd)
+                cmd = ('ovs-vsctl set interface gen1 ingress_policing_burst=100\n')
+                self.script_fd.write(cmd)
+
+    def add_vxlan_port(self):
+        for port in self.bridge_ports.keys():
+            if 'vxlan' in port:
+                cmd = ('ovs-vsctl -- --may-exist add-port br-fabric br-fab_vxlan0 -- set Interface br-fab_vxlan0 type=vxlan ofport=%s mac_in_use=\\"%s\\" options:remote_ip=flow options:key=flow options:dst_port=8472\n' %
+                (self.bridge_ports[port]['ofport'], self.bridge_ports[port]['mac']))
+                self.script_fd.write(cmd)
+
+    def create_script_file(self):
+        self.open_script_file()
+        self.create_tap_ports()
+        self.create_snat_ports()
+        self.add_tap_ports()
+        self.add_patch_ports()
+        self.add_snat_ports()
+        self.add_gen_ports()
+        self.add_vxlan_port()
+        self.close_script_file()

--- a/ovs/create-flowmods.sh
+++ b/ovs/create-flowmods.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+egrep -v OFPST_FLOW $1 | sed -e "s/^.*, table=/ovs-ofctl add-flow $2 -OOpenFlow13 \"table=/g" | sed -e 's/, n_packets=.*priority=/,priority=/g' | sed -e 's/ actions=/,actions=/g' | sed -e 's/$/"/g'


### PR DESCRIPTION
This adds a python script and a shell script, which can be used to recreate a dataplane (br-int and br-fabric ports, along with flow-mods). The bridge_ifs.py python module is used to create a script file (default is config-bridges.sh) that creates and adds tap ports, SNAT ports, and patch ports to the br-int and br-fabric bridges. The create-flowmods.sh shell script is used to sanitize the output of a ovs-ofctl dump-flows command, and converts that into individual ovs-ofctl add-flow commands in a file, which can be run to create the same flow-mods in OVS.