### PR TITLE
Add packaging and updating scripts

### DIFF
--- a/agent/tools/updates/README.md
+++ b/agent/tools/updates/README.md
@@ -1,0 +1,61 @@
+This directory contains ansible playbooks to update the opflex-agent binaries
+in a container, when using Red Hat OpenStack Platform (OSP) Director. There
+are three playbooks, two of which are always run:
+* update-opflex-agent-binaries.yaml (required)
+
+  This playbook stops the existing container, restarts it without running
+  the opflex agent. The tarball with the new binaries are copied into the
+  container, and a script is run to un-install the old binaries and install
+  the new ones.
+
+* update-opflex-agent-config.yaml (optional)
+
+  This playbook is used to update any configuration file changes needed. The
+  playbook provided in this repo has some example tasks, which you can use
+  as a reference to tailor this playbook however needed to update any config
+  for the agent.
+
+* run-new-opflex-agent.yaml (required)
+
+  This playbook restores the opflex-agent program in the container, and
+  restarts the container to run the new opflex agent.
+
+The playbooks should be copied to and run from the undercloud.
+
+# Pre-Upgrade process
+Before running the upgrade, you need to prepare a tarball of the new opflex-agent
+binaries. The relevant binaries are:
+* opflex-agent
+* opflex-agent-lib
+* opflex-agent-renderer-openvswitch
+* noiro-openvswitch-lib
+* noiro-openvswitch-otherlib
+* prometheus-cpp-lib
+* libmodelgbp
+* libopflex
+* libuv
+
+The RPMs for these files should be tar'd into a file called opflex-agent-tarball.tar, and then
+the file should be compressed using gzip, creating the opflex-agent-tarball.tar.gz tarball. That
+tarball needs to be copied to the undercloud VM so that the playbooks can be used to install it.
+
+# Upgrade process
+1. Obtain the cloud inventory for ansible. Run this from the /home/stack directory:
+
+<pre><code>$ source stackrc
+$ tripleo-ansible-inventory --ansible_ssh_user heat-admin --static-yaml-inventory ~/inventory.yaml
+</code></pre>
+
+2. ssh into each of the overcloud nodes, to add them to the undercloud's known_hosts file.
+
+<pre><code>$ for server in $(openstack server list -c Networks -f value | awk \
+-F"=" '{print $2}'); do ssh heat-admin@$server "ls"; done
+</code></pre>
+
+3. Run the playbooks to update the opflex agent on the nodes. You can limit which nodes
+   are upgraded using the -l argument:
+
+<pre><code>$ ansible-playbook -i inventory.txt update-opflex-agent-binaries.yaml -l overcloud-novacompute-0
+$ ansible-playbook -i inventory.txt update-opflex-agent-config.yaml -l overcloud-novacompute-0
+$ ansible-playbook -i inventory.txt run-new-opflex-agent.yaml -l overcloud-novacompute-0
+</code></pre>

--- a/agent/tools/updates/replace-binaries.sh
+++ b/agent/tools/updates/replace-binaries.sh
@@ -1,0 +1,64 @@
+#!/bin/sh
+CHECK_ONLY=$1
+REPLACE_LIBUV=0
+CURR_OPFLEX_AGENT=$(rpm -qa opflex-agent)
+CURR_OPFLEX_AGENT_LIB=$(rpm -qa opflex-agent-lib)
+CURR_OPFLEX_AGENT_RENDERER_OPENVSWITCH=$(rpm -qa opflex-agent-renderer-openvswitch)
+CURR_NOIRO_OPENVSWITCH_LIB=$(rpm -qa noiro-openvswitch-lib)
+CURR_NOIRO_OPENVSWITCH_OTHERLIB=$(rpm -qa noiro-openvswitch-otherlib)
+CURR_PROMETHEUS_CPP_LIB=$(rpm -qa prometheus-cpp-lib)
+CURR_LIBMODELGBP=$(rpm -qa libmodelgbp)
+CURR_LIBOPFLEX=$(rpm -qa libopflex)
+CURR_LIBUV=$(rpm -qa libuv)
+
+NEW_OPFLEX_AGENT=$(ls opflex-agent*.rpm | grep -v 'lib\|renderer')
+NEW_OPFLEX_AGENT_LIB=$(ls opflex-agent-lib*.rpm)
+NEW_OPFLEX_AGENT_RENDERER_OPENVSWITCH=$(ls opflex-agent-renderer-openvswitch*.rpm)
+NEW_NOIRO_OPENVSWITCH_LIB=$(ls noiro-openvswitch-lib*.rpm)
+NEW_NOIRO_OPENVSWITCH_OTHERLIB=$(ls noiro-openvswitch-otherlib*.rpm)
+NEW_PROMETHEUS_CPP_LIB=$(ls prometheus-cpp-lib*.rpm)
+NEW_LIBMODELGBP=$(ls libmodelgbp*.rpm)
+NEW_LIBOPFLEX=$(ls libopflex*.rpm)
+NEW_LIBUV=$(ls libuv*.rpm)
+
+echo "Replacing ${CURR_OPFLEX_AGENT} with ${NEW_OPFLEX_AGENT}"
+echo "Replacing ${CURR_OPFLEX_AGENT_LIB} with ${NEW_OPFLEX_AGENT_LIB}"
+echo "Replacing ${CURR_OPFLEX_AGENT_RENDERER_OPENVSWITCH} with ${NEW_OPFLEX_AGENT_RENDERER_OPENVSWITCH}"
+echo "Replacing ${CURR_NOIRO_OPENVSWITCH_LIB} with ${NEW_NOIRO_OPENVSWITCH_LIB}"
+echo "Replacing ${CURR_NOIRO_OPENVSWITCH_OTHERLIB} with ${NEW_NOIRO_OPENVSWITCH_OTHERLIB}"
+echo "Replacing ${CURR_PROMETHEUS_CPP_LIB} with ${NEW_PROMETHEUS_CPP_LIB}"
+echo "Replacing ${CURR_LIBMODELGBP} with ${NEW_LIBMODELGBP}"
+echo "Replacing ${CURR_LIBOPFLEX} with ${NEW_LIBOPFLEX}"
+echo "Replacing ${CURR_LIBUV} with ${NEW_LIBUV}"
+
+if [ "${CHECK_ONLY}" != '' ]; then
+   echo "Removing old packages...."
+   rpm -e ${CURR_OPFLEX_AGENT_RENDERER_OPENVSWITCH}
+   # Have to force this one, since opflex-agent and opflex-agent-lib are circular dependencies
+   rpm -e --nodeps ${CURR_OPFLEX_AGENT}
+   rpm -e ${CURR_OPFLEX_AGENT_LIB}
+   rpm -e ${CURR_LIBMODELGBP}
+   rpm -e ${CURR_LIBOPFLEX}
+   rpm -e ${CURR_NOIRO_OPENVSWITCH_LIB}
+   rpm -e ${CURR_NOIRO_OPENVSWITCH_OTHERLIB}
+   rpm -e ${CURR_PROMETHEUS_CPP_LIB}
+   # For now, don't remove, since the one installed is more recent
+   if [ "${REPLACE_LIBUV}" -ne 0 ]; then
+       rpm -e ${CURR_LIBUV}
+   fi
+
+   echo "Installing new packages...."
+   # For now, don't install, since the one installed is more recent
+   if [ "${REPLACE_LIBUV}" -ne 0 ]; then
+       rpm -i ${NEW_LIBUV}
+   fi
+   rpm -i ${NEW_PROMETHEUS_CPP_LIB}
+   rpm -i ${NEW_NOIRO_OPENVSWITCH_OTHERLIB}
+   rpm -i ${NEW_NOIRO_OPENVSWITCH_LIB}
+   rpm -i ${NEW_LIBOPFLEX}
+   rpm -i ${NEW_LIBMODELGBP}
+   # Have to force this one, since opflex-agent and opflex-agent-lib are circular dependencies
+   rpm -i --nodeps ${NEW_OPFLEX_AGENT_LIB}
+   rpm -i ${NEW_OPFLEX_AGENT}
+   rpm -i ${NEW_OPFLEX_AGENT_RENDERER_OPENVSWITCH}
+fi

--- a/agent/tools/updates/run-new-opflex-agent.yaml
+++ b/agent/tools/updates/run-new-opflex-agent.yaml
@@ -1,0 +1,15 @@
+---
+- name: Run the new opflex agent binaries
+  hosts: overcloud
+  become: yes
+  tasks:
+  - name: Step1. Restore the old ciscoaci_opflex_agent supervisord configuration file
+    copy:
+        src: /var/lib/config-data/puppet-generated/opflex/etc/opflex-agent-ovs/opflex_supervisord.conf.orig
+        dest: /var/lib/config-data/puppet-generated/opflex/etc/opflex-agent-ovs/opflex_supervisord.conf
+        remote_src: yes
+  - name: Step2. Retart the tripleo_ciscoaci_opflex_agent service, to use the new agent binaries and configuration
+    service:
+        name: tripleo_ciscoaci_opflex_agent
+        state: restarted
+

--- a/agent/tools/updates/update-opflex-agent-binaries.yaml
+++ b/agent/tools/updates/update-opflex-agent-binaries.yaml
@@ -1,0 +1,55 @@
+---
+- name: Change the binaries of the opflex agent
+  hosts: overcloud
+  become: yes
+  tasks:
+  - name: Step1. Stop the ciscoaci_opflex_agent container/service
+    service:
+        name: tripleo_ciscoaci_opflex_agent
+        state: stopped
+  - name: Step2. Save a copy of the current ciscoaci_opflex_agent supervisord configuration file
+    copy:
+        src: /var/lib/config-data/puppet-generated/opflex/etc/opflex-agent-ovs/opflex_supervisord.conf
+        dest: /var/lib/config-data/puppet-generated/opflex/etc/opflex-agent-ovs/opflex_supervisord.conf.orig
+        remote_src: yes
+  - name: Step3. Modify the supervisord to prevent launching of opflex_agent, mcast_daemon, and monitor script
+    # sh ./remove-programs.sh /var/lib/config-data/puppet-generated/opflex/etc/opflex-agent-ovs/opflex_supervisord.conf
+    replace:
+      path: /var/lib/config-data/puppet-generated/opflex/etc/opflex-agent-ovs/opflex_supervisord.conf
+      regexp: "{{ item.regexp }}"
+      replace: "{{ item.line }}"
+    with_items:
+    - {regexp: '^\[program:opflex-agent\]', line: '#[program:opflex-agent]'}
+    - {regexp: '^command=/bin/sh ', line: '#command=/bin/sh '}
+    - {regexp: '^exitcodes=0,2', line: '#exitcodes=0,2'}
+    - {regexp: '^stopasgroup=true', line: '#stopasgroup=true'}
+    - {regexp: '^startsecs=10', line: '#startsecs=10'}
+    - {regexp: '^startretries=3', line: '#startretries=3'}
+    - {regexp: '^stopwaitsecs=10', line: '#stopwaitsecs=10'}
+    - {regexp: '^stdout_logfile=NONE', line: '#stdout_logfile=NONE'}
+    - {regexp: '^stderr_logfile=NONE', line: '#stderr_logfile=NONE'}
+    - {regexp: '^\[program:monitor-ovs\]', line: '#[program:monitor-ovs]'}
+    - {regexp: '^\[program:mcast-d\]', line: '#[program:mcast-d]'}
+    - {regexp: '^command=/usr/bin/mcast_daemon ', line: '#command=/usr/bin/mcast_daemon '}
+    - {regexp: '^autorestart=true', line: '#autorestart=true'}
+  - name: Step4. Start the service, without those programs
+    service:
+        name: tripleo_ciscoaci_opflex_agent
+        state: started
+  - name: Step5. Copy the tarball with the new agent binaries to that host
+    copy:
+        src: /home/stack/opflex-agent-tarball.tar.gz
+        dest: /home/heat-admin/opflex-agent-tarball.tar.gz
+  - name: Step6. Copy the tarball of new opflex_agent binaries into the ciscoaci_opflex_agent container
+    shell: /bin/podman cp opflex-agent-tarball.tar.gz ciscoaci_opflex_agent:opflex-agent-tarball.tar.gz 
+  - name: Step7. Extract the tarball inside the container
+    shell: /bin/podman exec -u root ciscoaci_opflex_agent tar -xf opflex-agent-tarball.tar.gz
+  - name: Step8. Copy the script to replace the agent binaries to the host
+    copy:
+        src: /home/stack/replace-binaries.sh
+        dest: /home/heat-admin/replace-binaries.sh
+  - name: Step8. Copy the script to replace the agent binaries into the ciscoaci_opflex_agent container
+    shell: /bin/podman cp replace-binaries.sh ciscoaci_opflex_agent:replace-binaries.sh
+  - name: Step8. Run the script to remove the old binaries and install the new ones
+    become: yes
+    shell: /bin/podman exec -u root ciscoaci_opflex_agent sh /replace-binaries.sh -y

--- a/agent/tools/updates/update-opflex-agent-config.yaml
+++ b/agent/tools/updates/update-opflex-agent-config.yaml
@@ -1,0 +1,22 @@
+---
+- name: Update configuration files for the opflex agent
+  hosts: overcloud
+  become: yes
+  tasks:
+  - name: Step1. Add (and enable) the async JSON parser configuration for OVSDB
+    lineinfile:
+      dest: /var/lib/config-data/puppet-generated/opflex/etc/opflex-agent-ovs/conf.d/opflex-agent-ovs.conf
+      state: present
+      insertbefore: '    "feature": {'
+      line: "{{ item }}"
+    with_items:
+    - '    "ovs": {'
+    - '      "asyncjson" : { "enabled" : "false"}'
+    - '    },'
+  - name: Step2. Change the policy retry delay timeout value
+    replace:
+      path: /var/lib/config-data/puppet-generated/opflex/etc/opflex-agent-ovs/conf.d/opflex-agent-ovs.conf
+      regexp: "{{ item.regexp }}"
+      replace: "{{ item.line }}"
+    with_items:
+    - {regexp: '         "policy-retry-delay": 10', line: '         "policy-retry-delay": 120'


### PR DESCRIPTION
This patch adds playbooks and scripts that allow users to install new opflex-agent binaries on hosts deployed with Red Hat OSP.