### PR TITLE
New commands and fix

### DIFF
--- a/agent/policy_config.py
+++ b/agent/policy_config.py
@@ -17,7 +17,59 @@ import json
 import netaddr
 
 
-class PolicyObject(object):
+class BasePolicyObject(object):
+    def __init__(self, jsondict):
+        # Keep the original dict so we can display it
+        self.visited = False
+        self.jsondict = jsondict
+
+    def do_print(self):
+        print(json.dumps(self.jsondict, indent=4, sort_keys=True))
+
+
+class AimPolicyObject(BasePolicyObject):
+    """AIM Hash Tree Policy Object
+
+    AIM JSON hash tree policy objects take the form:
+    {
+        "key": [ list of <object type|name>],
+        "full_hash": <string>,
+        "partial_hash": <string>,
+        "dummy": <parent object type>
+        "error": <uri of parent>
+        "metadata": [ <list of properties> ]
+        "_children": [ <list of child objects> ]
+    }
+    """
+
+    def __init__(self, jsondict):
+        if not jsondict.get('key'):
+            print("Warning: object with no key")
+            return None
+
+        self.key = jsondict['key']
+        # Create URI from the key
+        self.uri = '/'.join(self.key)
+        def get_type(elem_dn):
+            return elem_dn.split('|')[0]
+        #self.obj_type = '/'.join(list(map(get_type, jsondict['key'])))
+        self.obj_type = jsondict['key'][-1].split('|')[0]
+        
+        self.full_hash = jsondict['full_hash']
+        self.partial_hash = jsondict['partial_hash']
+        self.dummy = jsondict['dummy']
+        self.error = jsondict['error']
+        if jsondict.get('metadata'):
+            self.metadata = jsondict.get('metadata')
+        # Convert the children dictionary objects into key strings
+        self.children = jsondict['children']
+        super(AimPolicyObject, self).__init__(jsondict)
+
+    def _get_property(self, property_name):
+        return self.metadata.get('attributes').get(property_name)
+
+
+class AgentPolicyObject(BasePolicyObject):
     """Opflex Policy Object
 
     Opflex JSON policy objects take the form:
@@ -43,6 +95,7 @@ class PolicyObject(object):
 
         self.uri = jsondict['uri']
         self.subject = jsondict['subject']
+        self.obj_type = self.subject
         self.properties = jsondict.get('properties', [])
         self.children = jsondict.get('children', [])
         if jsondict.get('parent_uri'):
@@ -51,17 +104,129 @@ class PolicyObject(object):
             self.parent_subject = jsondict.get('parent_subject')
         if jsondict.get('parent_relation'):
             self.parent_relation = jsondict.get('parent_relation')
-        # Keep the original dict so we can display it
-        self.visited = False
-        self.jsondict = jsondict
+        super(AgentPolicyObject, self).__init__(jsondict)
 
     def _get_property(self, property_name):
         for prop in self.properties:
             if prop.get('name') == property_name:
                 return prop
 
-    def do_print(self):
-        print(json.dumps(self.jsondict, indent=4, sort_keys=True))
+
+class AimPolicyIterator(object):
+    """AIM Policy Iterator
+
+    AIM JSON policy iterator. AIM policy is a JSON dictionary that is organized
+    hierarchically. Child objects are in lists of the parent, and relationships
+    are made using the "_children" elements of each dictionary object and "tDn"
+    referecnes in the "metadata" field.
+    """
+    def __init__(self, object_instance, policy):
+        self.idx = 0
+        self.policy = policy
+        self.object_instance = object_instance
+        self.flatten_dict(self.policy)
+
+
+    def flatten_dict(self, policy):
+        # Go through and flatten everything into a single
+        # list of dictionary objects
+        for obj_dict in policy:
+            children = obj_dict.pop('_children', [])
+            obj_dict['children'] = []
+            # Replace the child objects with just child DNs,
+            # and add each child object to the top level policy list.
+            for child in children:
+                obj_dict['children'].append('/'.join(child.get('key')))
+                self.policy.append(child)
+            # Now flatten all of the children
+            self.flatten_dict(children)
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        """Get next object
+
+        This is a depth-first iterator.
+        """
+        if self.idx >= len(self.policy):
+            raise StopIteration
+        obj_dict = self.policy[self.idx]
+        self.idx += 1
+        return self.object_instance(obj_dict)
+
+
+class AgentPolicyIterator(object):
+    """Opflex Policy Iterator
+
+    Opflex JSON policy iterator. Opflex policy is organized
+    as a flat list. Relationships are made using the "children"
+    elements of each dictionary object, as well as "target"
+    referecnes.
+    """
+    def __init__(self, object_instance, policy):
+        self.idx = 0
+        self.policy = policy
+        self.object_instance = object_instance
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        if self.idx >= len(self.policy):
+            raise StopIteration
+        obj_dict = self.policy[self.idx]
+        self.idx += 1
+        return self.object_instance(obj_dict)
+
+
+
+###################################################################
+# These currently aren't used -- we'll probably just use the dicts
+class AgentPropertiesObject(object):
+    """Opflex Property Object
+
+    Opflex property objects are elements in a list of
+    propertiy objects kept by the polciy object. Items in
+    the list take on the form of:
+    {
+        "name": <string for the name>,
+        "data": <scalar or dict>
+    }
+    """
+
+    def __init__(self, jsondict):
+        if jsondict.get('name'):
+            self.name = jsondict['name']
+
+        if jsondict.get('data'):
+            if self.name == 'target':
+                if not isinstance(jsondict['data'], dict):
+                    print("Data is target, but not a dict")
+                    return None
+            self.data = jsondict['data']
+
+
+class AgentDataObject(object):
+    """Opflex Property Data Object
+
+    Opflex property data can be either scalar elements, or
+    if the property name was "target", dictionaries with the form:
+    {
+        "subject": <type of object referenced>,
+        "reference_uri": <URI of the referenced object>
+    }
+    """
+
+    def __init__(self, jsondict):
+        if not jsondict.get('subject'):
+            print("No subject in Data")
+            return None
+        if jsondict.get('reference_uri'):
+            print("No reference_uri in Data")
+            return None
+        self.subject = jsondict['subject']
+        self.reference_uri = jsondict['reference_uri']
 
 
 
@@ -71,23 +236,36 @@ class PolicyConfigManager(object):
     This class provides a set of APIs to introspect policy data.
     """
 
-    def __init__(self, policy_filename):
+    def __init__(self, policy_filename, policy_type='agent'):
         self.filename = policy_filename
         self.objects_by_uri = {}
         self.objects_by_type = {}
-        self.parsed_policy = []
+        self.json_policy = []
+        self.policy_type = policy_type
+        if self.policy_type == 'agent':
+            self.target_string = 'target'
+            self.obj_instance = AgentPolicyObject
+            self.obj_iterator = AgentPolicyIterator
+        elif self.policy_type == 'aim':
+            self.target_string = 'tDn'
+            self.obj_instance = AimPolicyObject
+            self.obj_iterator = AimPolicyIterator
+        else:
+            self.obj_instance = object
+            self.obj_iterator = object
+
         self._get_policy_json()
         self._json_to_objects()
 
     def _json_to_objects(self):
-        for item in self.parsed_policy:
-            obj = PolicyObject(item)
-            self.objects_by_type.setdefault(obj.subject, []).append(obj)
+        obj_iterator = self.obj_iterator(self.obj_instance, self.json_policy)
+        for obj in  obj_iterator:
+            self.objects_by_type.setdefault(obj.obj_type, []).append(obj)
             self.objects_by_uri[obj.uri] = obj
 
     def _get_policy_json(self):
         with open(self.filename, 'r') as fd:
-            self.parsed_policy = json.load(fd)
+            self.json_policy = json.load(fd)
 
     def list_l3_eps(self):
         """List all of the Layer 3 policy objects
@@ -104,9 +282,22 @@ class PolicyConfigManager(object):
         self.list_objects_by_type('EpdrLocalL2Ep')
 
     def list_objects_by_type(self, object_type):
-        """List all of the policy objects that have the same subject"""
+        """List all of the policy objects that have the same obj_type"""
         for opflex_obj in self.objects_by_type.get(object_type, []):
             opflex_obj.do_print()
+
+    def count_objects_by_type(self, object_type):
+        print('%(type)s: %(number)s' % {
+            'type': object_type,
+            'number': len(self.objects_by_type.get(object_type, []))})
+
+    def count_objects(self, details=False):
+        if details:
+            for object_type in self.objects_by_type:
+                self.count_objects_by_type(object_type)
+
+        print('%(number)s objects' % {
+            'number': len(self.objects_by_uri)})
 
     def list_vms(self):
         """List all the VM policy objects
@@ -185,7 +376,7 @@ class PolicyConfigManager(object):
         exists in the policy.
         """
         for opflex_obj in list(self.objects_by_uri.values()):
-            target = opflex_obj._get_property('target')
+            target = opflex_obj._get_property(self.target_string)
             if target:
                 target_uri = target['data']['reference_uri']
                 if not self.objects_by_uri.get(target_uri):
@@ -204,66 +395,26 @@ class PolicyConfigManager(object):
         for addition in additions:
             policy_obj = policy_conf_2.objects_by_uri[addition]
             print("########## Added %(policy_type)s with URI %(uri)s" % {
-                'policy_type': policy_obj.subject,
+                'policy_type': policy_obj.obj_type,
                 'uri': policy_obj.uri})
         for deletion in deletions:
             policy_obj = self.objects_by_uri[deletion]
             print("########## Deleted %(policy_type)s with URI %(uri)s" % {
-                'policy_type': policy_obj.subject,
+                'policy_type': policy_obj.obj_type,
                 'uri': policy_obj.uri})
         for key in keys1 & keys2:
-            policy_obj1 = self.objects_by_uri[key]
-            policy_obj2 = policy_conf_2.objects_by_uri[key]
-            if policy_obj1.jsondict != policy_obj2.jsondict:
+            policy_obj1 = self.objects_by_uri[key].jsondict
+            policy_obj2 = policy_conf_2.objects_by_uri[key].jsondict
+            o1_children = set(policy_obj1.pop('children'))
+            o2_children = set(policy_obj2.pop('children'))
+            if policy_obj1 == policy_obj2:
+                # Check to see if the ordering of the children
+                if (o2_children - o1_children) or (o1_children - o2_children):
+                    # objects changed - if so, ignore.
+                    print("########## Changed %(policy_type)s with URI %(uri)s " % {
+                          'policy_type': policy_obj1['subject'],
+                          'uri': policy_obj1['uri']})
+            else:
                 print("########## Changed %(policy_type)s with URI %(uri)s " % {
-                'policy_type': policy_obj1.subject,
-                'uri': policy_obj1.uri})
-
-
-###################################################################
-# These currently aren't used -- we'll probably just use the dicts
-class PropertiesObject(object):
-    """Opflex Property Object
-
-    Opflex property objects are elements in a list of
-    propertiy objects kept by the polciy object. Items in
-    the list take on the form of:
-    {
-        "name": <string for the name>,
-        "data": <scalar or dict>
-    }
-    """
-
-    def __init__(self, jsondict):
-        if jsondict.get('name'):
-            self.name = jsondict['name']
-
-        if jsondict.get('data'):
-            if self.name == 'target':
-                if not isinstance(jsondict['data'], dict):
-                    print("Data is target, but not a dict")
-                    return None
-            self.data = jsondict['data']
-
-
-class DataObject(object):
-    """Opflex Property Data Object
-
-    Opflex property data can be either scalar elements, or
-    if the property name was "target", dictionaries with the form:
-    {
-        "subject": <type of object referenced>,
-        "reference_uri": <URI of the referenced object>
-    }
-    """
-
-    def __init__(self, jsondict):
-        if not jsondict.get('subject'):
-            print("No subject in Data")
-            return None
-        if jsondict.get('reference_uri'):
-            print("No reference_uri in Data")
-            return None
-        self.subject = jsondict['subject']
-        self.reference_uri = jsondict['reference_uri']
-
+                     'policy_type': policy_obj1['subject'],
+                     'uri': policy_obj1['uri']})

--- a/agent/policy_db.py
+++ b/agent/policy_db.py
@@ -28,32 +28,42 @@ def policy_db():
               help='Policy file name (JSON)')
 @click.option('--endpoint', required=True,
               help='ID of endpoint (L2 MAC or L3 IP)')
-def ep_info(policy_file, endpoint):
-    policy_conf = policy_config.PolicyConfigManager(policy_file)
+@click.option('--policy-type', required=False, default='agent',
+              help='Type of policy file ("agent" or "aim")')
+def ep_info(policy_file, policy_type, endpoint):
+    policy_conf = policy_config.PolicyConfigManager(policy_file,
+                                                    policy_type=policy_type)
     policy_conf.get_policy_for_ep(endpoint)
 
 
 @policy_db.command(name="list-l2-eps")
 @click.option('--policy-file',required=True,
               help='Policy file name (JSON)')
-def list_l2_eps(policy_file):
-    policy_conf = policy_config.PolicyConfigManager(policy_file)
+@click.option('--policy-type', required=False, default='agent',
+              help='Type of policy file ("agent" or "aim")')
+def list_l2_eps(policy_file, policy_type):
+    policy_conf = policy_config.PolicyConfigManager(policy_file,
+                                                    policy_type=policy_type)
     policy_conf.list_l2_eps()
 
 
 @policy_db.command(name="list-l3-eps")
 @click.option('--policy-file',required=True,
               help='Policy file name (JSON)')
-def list_l3_eps(policy_file):
-    policy_conf = policy_config.PolicyConfigManager(policy_file)
+@click.option('--policy-type', required=False, default='agent',
+              help='Type of policy file ("agent" or "aim")')
+def list_l3_eps(policy_file, policy_type):
+    policy_conf = policy_config.PolicyConfigManager(policy_file,
+                                                    policy_type=policy_type)
     policy_conf.list_l3_eps()
 
 
 @policy_db.command(name="list-vms")
 @click.option('--policy-file',required=True,
               help='Policy file name (JSON)')
-def list_vms(policy_file):
-    policy_conf = policy_config.PolicyConfigManager(policy_file)
+def list_vms(policy_file, policy_type):
+    policy_conf = policy_config.PolicyConfigManager(policy_file,
+                                                    policy_type=policy_type)
     policy_conf.list_vms()
 
 
@@ -62,15 +72,48 @@ def list_vms(policy_file):
               help='Policy file name (JSON)')
 @click.option('--policy-name',required=True,
               help='Name of the type of policy objects to find')
-def find_policy(policy_file, policy_name):
-    policy_conf = policy_config.PolicyConfigManager(policy_file)
+@click.option('--policy-type', required=False, default='agent',
+              help='Type of policy file ("agent" or "aim")')
+def find_policy(policy_file, policy_type, policy_name):
+    policy_conf = policy_config.PolicyConfigManager(policy_file,
+                                                    policy_type=policy_type)
     policy_conf.list_objects_by_type(policy_name)
+
+
+@policy_db.command(name="count-policy")
+@click.option('--policy-file',required=True,
+              help='Policy file name (JSON)')
+@click.option('--policy-name',required=True,
+              help='Name of the type of policy objects to find')
+@click.option('--policy-type', required=False, default='agent',
+              help='Type of policy file ("agent" or "aim")')
+def count_policy(policy_file, policy_type, policy_name):
+    policy_conf = policy_config.PolicyConfigManager(policy_file,
+                                                    policy_type=policy_type)
+    policy_conf.count_objects_by_type(policy_name)
+
+
+@policy_db.command(name="count-all")
+@click.option('--policy-file',required=True,
+              help='Policy file name (JSON)')
+@click.option('--policy-type', required=False, default='agent',
+              help='Type of policy file ("agent" or "aim")')
+@click.option('--details/--no-details',required=False,default=False,
+              help='Show per-class counts as well')
+def count_policy(policy_file, policy_type, details=False):
+    policy_conf = policy_config.PolicyConfigManager(policy_file,
+                                                    policy_type=policy_type)
+    policy_conf.count_objects(details=details)
+
 
 @policy_db.command(name="find-unresolved")
 @click.option('--policy-file',required=True,
               help='Policy file name (JSON)')
-def find_unresolved(policy_file):
-    policy_conf = policy_config.PolicyConfigManager(policy_file)
+@click.option('--policy-type', required=False, default='agent',
+              help='Type of policy file ("agent" or "aim")')
+def find_unresolved(policy_file, policy_type):
+    policy_conf = policy_config.PolicyConfigManager(policy_file,
+                                                    policy_type=policy_type)
     policy_conf.find_unresolved_policy()
 
 @policy_db.command(name="diff-policy")
@@ -78,9 +121,13 @@ def find_unresolved(policy_file):
               help='Policy file 1 name (JSON)')
 @click.option('--policy-file-2',required=True,
               help='Policy file 2 name (JSON)')
-def find_unresolved(policy_file_1, policy_file_2):
-    policy_conf_1 = policy_config.PolicyConfigManager(policy_file_1)
-    policy_conf_2 = policy_config.PolicyConfigManager(policy_file_2)
+@click.option('--policy-type', required=False, default='agent',
+              help='Type of policy file ("agent" or "aim")')
+def find_unresolved(policy_file_1, policy_type, policy_file_2):
+    policy_conf_1 = policy_config.PolicyConfigManager(policy_file_1,
+                                                      policy_type=policy_type)
+    policy_conf_2 = policy_config.PolicyConfigManager(policy_file_2,
+                                                      policy_type=policy_type)
     policy_conf_1.diff_policy(policy_conf_2)
 
 


### PR DESCRIPTION
This adds commands to count the number of MOs, as well as a fix for policy comparisons. This change relaces the compare for the order of children declared by the parent. As long as the child MOs are the same, their order shouldn't matter when doing logical policy comparisons. It also adds the ability to handle AIM hash tree dumps.